### PR TITLE
Loading configure.zcml was broken due to the renaming of the types module

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,10 @@ CHANGES
 2.0.0a2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Restore the ability to write `from zope.mimetype import types`.
+
+- Make `configure.zcml` respect the renaming of the `types` module
+  so that it can be loaded.
 
 
 2.0.0a1 (2013-02-27)
@@ -18,6 +21,8 @@ CHANGES
 
 - Replaced deprecated ``zope.interface.implements`` usage with equivalent
   ``zope.interface.implementer`` decorator.
+
+- Renamed `zope.mimetype.types` to `zope.mimetype.mtypes`.
 
 - Dropped support for Python 2.4 and 2.5.
 

--- a/src/zope/mimetype/__init__.py
+++ b/src/zope/mimetype/__init__.py
@@ -1,1 +1,2 @@
 from zope.mimetype import mtypes
+types = mtypes # alternate spelling/backwards (1.3) compatible export

--- a/src/zope/mimetype/configure.zcml
+++ b/src/zope/mimetype/configure.zcml
@@ -3,7 +3,7 @@
     i18n_domain="zope.mimetype">
 
   <mimeTypes
-      module=".types"
+      module=".mtypes"
       file="types.csv"
       />
 


### PR DESCRIPTION
Commit 37e48407c0e1273bc57b34b520e6e79e7a985a72 renamed `types.py` to `mtypes.py`. `configure.zcml` was still referencing a module named `.types` and so it couldn't be loaded, failing with an error like:

```
Module zope.configuration.fields, line 74, in fromUnicode
  raise ValidationError(v)
ZopeXMLConfigurationError: File "zope.mimetype-2.0.0a1-py2.7.egg/zope/mimetype/configure.zcml", line 5.2-8.8
ConfigurationError: ('Invalid value for', 'module', 'ImportError: Module zope.mimetype has no global types')
```

This pull request alters `configure.zcml` to use the new name. 

It also adds a global to `__init__.py` to restore a measure of backwards compatibility, allowing `from zope.mimetype import types`. The renaming is still a partially backwards incompatible change (since you can no longer write `import zope.mimetype.types`), so it also adds a note to `CHANGES.txt`.
