### PR TITLE
Fix winbot build

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -19,10 +19,10 @@ scripts = coverage=coverage-report
 arguments = ('coverage', 'coverage/report')
 
 [versions]
-zope.browserpage = 4.1.0a1
-zope.formlib = 4.3.0a1
-zope.i18n = 4.0.0a4
-zope.publisher = 4.0.0a2
-zope.security = 4.0.0a3
-zope.tal = 4.0.0a1
-zope.traversing = 4.0.0a2
+zope.browserpage = 4.1.0
+zope.formlib = 4.3.0
+zope.i18n = 4.0.1
+zope.publisher = 4.2.1
+zope.security = 4.0.3
+zope.tal = 4.1.1
+zope.traversing = 4.0.0

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,7 +1,6 @@
 [buildout]
 develop = .
 parts = test coverage-test coverage-report
-versions = versions
 
 [test]
 recipe = zc.recipe.testrunner
@@ -17,12 +16,3 @@ recipe = zc.recipe.egg
 eggs = z3c.coverage
 scripts = coverage=coverage-report
 arguments = ('coverage', 'coverage/report')
-
-[versions]
-zope.browserpage = 4.1.0
-zope.formlib = 4.3.0
-zope.i18n = 4.0.1
-zope.publisher = 4.2.1
-zope.security = 4.0.3
-zope.tal = 4.1.1
-zope.traversing = 4.0.0


### PR DESCRIPTION
The nightly winbot build broke due to changes in dependencies leading the version pins in `buildout.cfg` to be incompatible.
