### PR TITLE
Use absolute import for i18n

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changes
 
 - Drop support for Python 2.6.
 
+- Fix configuring the package via its included ZCML on Python 3.
 
 2.0.0 (2014-12-24)
 --------------------

--- a/src/zope/mimetype/configure.txt
+++ b/src/zope/mimetype/configure.txt
@@ -1,0 +1,19 @@
+Package configuration
+=====================
+
+The ``zope.mimetype`` package provides a ZCML file that configures some
+adapters and utilities and a couple of views:
+
+  >>> from zope.configuration.xmlconfig import XMLConfig
+  >>> import zope.mimetype
+
+  >>> len(list(zope.component.getGlobalSiteManager().registeredUtilities()))
+  0
+
+  >>> XMLConfig('configure.zcml', zope.mimetype)()
+
+  >>> len(list(zope.component.getGlobalSiteManager().registeredUtilities())) >= 760
+  True
+
+  >>> len(list(zope.component.getGlobalSiteManager().registeredAdapters()))
+  107

--- a/src/zope/mimetype/configure.zcml
+++ b/src/zope/mimetype/configure.zcml
@@ -2,6 +2,9 @@
     xmlns="http://namespaces.zope.org/zope"
     i18n_domain="zope.mimetype">
 
+  <include package="zope.component" file="meta.zcml" />
+  <include package="zope.mimetype" file="meta.zcml" />
+
   <mimeTypes
       module=".mtypes"
       file="types.csv"

--- a/src/zope/mimetype/tests.py
+++ b/src/zope/mimetype/tests.py
@@ -91,10 +91,15 @@ def test_suite():
                 setUp=testing.setUp, tearDown=testing.tearDown,
                 checker=checker),
         doctest.DocFileSuite(
-            'codec.txt',
-            optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS,
-            checker=checker,
-            ),
+                'codec.txt',
+                optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS,
+                checker=checker,
+        ),
+        doctest.DocFileSuite(
+                'configure.txt',
+                setUp=testing.setUp, tearDown=testing.tearDown,
+                checker=checker
+        ),
         ))
 
 if __name__ == '__main__':

--- a/src/zope/mimetype/zcml.py
+++ b/src/zope/mimetype/zcml.py
@@ -16,8 +16,8 @@ import os.path
 from zope import interface
 from zope import schema
 from zope.configuration import fields
-from i18n import _
 
+from zope.mimetype.i18n import _
 from zope.mimetype import codec
 from zope.mimetype import interfaces
 from zope.mimetype import mtypes

--- a/src/zope/mimetype/zcml.py
+++ b/src/zope/mimetype/zcml.py
@@ -55,7 +55,7 @@ def mimeTypesDirective(_context, file, module):
     directory = os.path.dirname(file)
     data = mtypes.read(file)
     provides = interfaces.IContentTypeInterface
-    for name, info in data.iteritems():
+    for name, info in data.items():
         iface = getattr(module, name, None)
         if iface is None:
             # create missing interface


### PR DESCRIPTION
Without this, when our project uses ZCML to configure zope.mimetype under Python 3.4 or 3.5, we get this error:

```
Traceback (most recent call last):
  File "//lib/python3.4/site-packages/zope/configuration/xmlconfig.py", line 272, in endElementNS
    self.context.end()
  File "//lib/python3.4/site-packages/zope/configuration/config.py", line 345, in end
    self.stack.pop().finish()
  File "//lib/python3.4/site-packages/zope/configuration/config.py", line 453, in finish
    actions = self.handler(context, **args)
  File "//lib/python3.4/site-packages/zope/configuration/xmlconfig.py", line 402, in include
    processxmlfile(f, context)
  File "//lib/python3.4/site-packages/zope/configuration/xmlconfig.py", line 295, in processxmlfile
    parser.parse(src)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/xml/sax/expatreader.py", line 110, in parse
    xmlreader.IncrementalParser.parse(self, source)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/xml/sax/xmlreader.py", line 123, in parse
    self.feed(buffer)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/xml/sax/expatreader.py", line 210, in feed
    self._parser.Parse(data, isFinal)
  File "/opt/local/var/macports/build/_opt_mports_dports_lang_python34/python34/work/Python-3.4.5/Modules/pyexpat.c", line 405, in StartElement
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/xml/sax/expatreader.py", line 354, in start_element_ns
    AttributesNSImpl(newattrs, qnames))
  File "//lib/python3.4/site-packages/zope/configuration/xmlconfig.py", line 213, in startElementNS
    None, sys.exc_info()[2])
  File "//lib/python3.4/site-packages/zope/configuration/_compat.py", line 38, in reraise
    raise value.with_traceback(tb)
  File "//lib/python3.4/site-packages/zope/configuration/xmlconfig.py", line 204, in startElementNS
    self.context.begin(name, data, info)
  File "//lib/python3.4/site-packages/zope/configuration/config.py", line 342, in begin
    self.stack.append(self.stack[-1].contained(__name, __data, __info))
  File "//lib/python3.4/site-packages/zope/configuration/config.py", line 509, in contained
    return RootStackItem.contained(self, name, data, info)
  File "//lib/python3.4/site-packages/zope/configuration/config.py", line 476, in contained
    adapter = factory(self.context, data, info)
  File "//lib/python3.4/site-packages/zope/configuration/config.py", line 706, in factory
    args = toargs(context, schema, data)
  File "//lib/python3.4/site-packages/zope/configuration/config.py", line 794, in toargs
    args[str(name)] = field.fromUnicode(s)
  File "//lib/python3.4/site-packages/zope/configuration/fields.py", line 72, in fromUnicode
    value = self.context.resolve(name)
  File "//lib/python3.4/site-packages/zope/configuration/config.py", line 151, in resolve
    mod = __import__(mname, *_import_chickens)
  File "//lib/python3.4/site-packages/zope/mimetype/zcml.py", line 19, in <module>
    from i18n import _
zope.configuration.xmlconfig.ZopeXMLConfigurationError: File "//lib/python3.4/site-packages/zope/mimetype/meta.zcml", line 8.4
    ImportError: No module named 'i18n'
```