### PR TITLE
Only register the browser stuff when `zope.formlib` is available.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 2.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Only try to register the browser stuff in the ZCA when `zope.formlib` is
+  available as it breaks otherwise.
 
 
 2.3.0 (2017-09-28)

--- a/src/zope/mimetype/configure.zcml
+++ b/src/zope/mimetype/configure.zcml
@@ -23,7 +23,7 @@
 
   <adapter factory=".contentinfo.ContentInfo"/>
 
-  <configure zcml:condition="installed zope.browser">
+  <configure zcml:condition="installed zope.formlib">
 
     <adapter factory=".source.CodecTerms"/>
     <adapter factory=".source.ContentTypeTerms"/>

--- a/src/zope/mimetype/configure.zcml
+++ b/src/zope/mimetype/configure.zcml
@@ -24,6 +24,9 @@
   <adapter factory=".contentinfo.ContentInfo"/>
 
   <configure zcml:condition="installed zope.formlib">
+    <!-- Actually zope.browser is needed, too, but it is currently a direct
+         dependency of zope.formlib.
+    -->
 
     <adapter factory=".source.CodecTerms"/>
     <adapter factory=".source.ContentTypeTerms"/>


### PR DESCRIPTION
If it is not there reading `configure.zcml` breaks when importing `widget.py`.