### PR TITLE
Really enable Python 3.7 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,15 @@ python:
     - 3.6
     - pypy
     - pypy3
+env:
+    - DEP=test
 matrix:
     include:
         - python: "3.7"
           dist: xenial
           sudo: true
-env:
-    - DEP=test
-matrix:
-  include:
-    - python: 2.7
-      env: DEP=no_such_extra
+        - python: 2.7
+          env: DEP=no_such_extra
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls zope.testing zope.testrunner


### PR DESCRIPTION
We had two 'matrix' entries at the top level, and the second overrode
the first one because that's how YAML works.