### PR TITLE
Enforce strict IRO globally.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,12 @@ python:
     - pypy
     - pypy3
 env:
-  - DEP: test
-  - DEP: no_such_extra
-    # Cannot yet set this globally pending
-    # https://github.com/zopefoundation/zope.publisher/issues/49
-    ZOPE_INTERFACE_STRICT_IRO: 1
+  global:
+    - ZOPE_INTERFACE_STRICT_IRO: 1
+  jobs:
+    - DEP: test
+    - DEP: no_such_extra
+
 
 install:
     - pip install -U pip setuptools

--- a/tox.ini
+++ b/tox.ini
@@ -7,16 +7,14 @@ commands =
     zope-testrunner --test-path=src []
 extras =
     test
+setenv =
+    ZOPE_INTERFACE_STRICT_IRO=1
 
 [testenv:minimal]
 extras =
 deps =
     zope.testrunner
     zope.testing
-# Cannot yet set this globally, pending
-# https://github.com/zopefoundation/zope.publisher/issues/49
-setenv =
-    ZOPE_INTERFACE_STRICT_IRO=1
 
 [testenv:coverage]
 usedevelop = true


### PR DESCRIPTION
Now that zope.traversing and zope.formlib are in compliance.

(This package sure has a lot of surprising dependencies.)

Finally fixes #17 

No change note, purely internal testing details.