### PR TITLE
Fix test compatibility with zope.interface 5.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 2.5.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix test compatibility with zope.interface 5.4.
 
 
 2.5.0 (2020-03-30)

--- a/src/zope/mimetype/event.rst
+++ b/src/zope/mimetype/event.rst
@@ -15,8 +15,8 @@ that simply prints out the information from the event object::
 
   >>> def handler(event):
   ...     print("changed content type interface:")
-  ...     print("  from:", event.oldContentType)
-  ...     print("    to:", event.newContentType)
+  ...     print("  from:", repr(event.oldContentType))
+  ...     print("    to:", repr(event.newContentType))
 
 We'll also define a simple content object::
 


### PR DESCRIPTION
Explicitly use the repr of interfaces so we can work with any version of zope.interface.

See https://github.com/zopefoundation/zope.interface/pull/237#issuecomment-807188771